### PR TITLE
feat: throw error on missing config properties

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,6 +32,7 @@ module.exports = {
         'max-statements': 'off',
         'no-magic-numbers': 'off',
         'require-await': 'off',
+        'unicorn/consistent-function-scoping': 'off',
       },
     },
   ],

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -191,6 +191,37 @@ describe('get', () => {
 
     expect(await blobs.get(key)).toBeNull()
   })
+
+  test('Throws when the instance is missing required configuration properties', async () => {
+    const fetcher = (...args: Parameters<typeof globalThis.fetch>) => {
+      const [url] = args
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    }
+
+    const blobs1 = new Blobs({
+      authentication: {
+        token: '',
+      },
+      fetcher,
+      siteID,
+    })
+
+    const blobs2 = new Blobs({
+      authentication: {
+        token: apiToken,
+      },
+      fetcher,
+      siteID: '',
+    })
+
+    expect(async () => await blobs1.get(key)).rejects.toThrowError(
+      `The blob store is unavailable because it's missing required configuration properties`,
+    )
+    expect(async () => await blobs2.get(key)).rejects.toThrowError(
+      `The blob store is unavailable because it's missing required configuration properties`,
+    )
+  })
 })
 
 describe('set', () => {
@@ -300,6 +331,37 @@ describe('set', () => {
       'put operation has failed: API returned a 401 response',
     )
   })
+
+  test('Throws when the instance is missing required configuration properties', async () => {
+    const fetcher = (...args: Parameters<typeof globalThis.fetch>) => {
+      const [url] = args
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    }
+
+    const blobs1 = new Blobs({
+      authentication: {
+        token: '',
+      },
+      fetcher,
+      siteID,
+    })
+
+    const blobs2 = new Blobs({
+      authentication: {
+        token: apiToken,
+      },
+      fetcher,
+      siteID: '',
+    })
+
+    expect(async () => await blobs1.set(key, value)).rejects.toThrowError(
+      `The blob store is unavailable because it's missing required configuration properties`,
+    )
+    expect(async () => await blobs2.set(key, value)).rejects.toThrowError(
+      `The blob store is unavailable because it's missing required configuration properties`,
+    )
+  })
 })
 
 describe('delete', () => {
@@ -370,6 +432,37 @@ describe('delete', () => {
 
     expect(async () => await blobs.delete(key)).rejects.toThrowError(
       'delete operation has failed: API returned a 401 response',
+    )
+  })
+
+  test('Throws when the instance is missing required configuration properties', async () => {
+    const fetcher = (...args: Parameters<typeof globalThis.fetch>) => {
+      const [url] = args
+
+      throw new Error(`Unexpected fetch call: ${url}`)
+    }
+
+    const blobs1 = new Blobs({
+      authentication: {
+        token: '',
+      },
+      fetcher,
+      siteID,
+    })
+
+    const blobs2 = new Blobs({
+      authentication: {
+        token: apiToken,
+      },
+      fetcher,
+      siteID: '',
+    })
+
+    expect(async () => await blobs1.delete(key)).rejects.toThrowError(
+      `The blob store is unavailable because it's missing required configuration properties`,
+    )
+    expect(async () => await blobs2.delete(key)).rejects.toThrowError(
+      `The blob store is unavailable because it's missing required configuration properties`,
     )
   })
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,12 +91,20 @@ export class Blobs {
     }
   }
 
+  private isConfigured() {
+    return Boolean(this.authentication?.token) && Boolean(this.siteID)
+  }
+
   private async makeStoreRequest(
     key: string,
     method: HTTPMethod,
     extraHeaders?: Record<string, string>,
     body?: BlobInput | null,
   ) {
+    if (!this.isConfigured()) {
+      throw new Error("The blob store is unavailable because it's missing required configuration properties")
+    }
+
     const { headers: baseHeaders = {}, method: finalMethod, url } = await this.getFinalRequest(key, method)
     const headers: Record<string, string> = {
       ...baseHeaders,


### PR DESCRIPTION
**Which problem is this pull request solving?**

Makes the blobs client throw an error on `get()`, `set()` and `delete()` operations if the store is missing required configuration properties, such as the authentication token or the site ID.

This is useful so that we can always instantiate a store, even if it is a no-op store in cases where the information required is missing. For example, we'll use this when gradually rolling out support for the blob store in edge functions.