### PR TITLE
fix: workaround for a cloudfront issue where it throws on a 403

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -20,6 +20,7 @@ beforeAll(async () => {
     globalThis.Request = nodeFetch.Request
     // @ts-expect-error Expected type mismatch between native implementation and node-fetch
     globalThis.Response = nodeFetch.Response
+    // @ts-expect-error Expected type mismatch between native implementation and node-fetch
     globalThis.Headers = nodeFetch.Headers
   }
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -158,7 +158,10 @@ export class Blobs {
 
     const res = await fetchAndRetry(this.fetcher, url, options)
 
-    if (res.status === 404 && method === HTTPMethod.Get) {
+    // Temp fix for:
+    // Cloudfront currently returns a 403 if it cannot find the artefact instead of returning a 404
+    // Workaround for: https://github.com/netlify/pod-dev-foundations/issues/592
+    if ((res.status === 403 || res.status === 404) && method === HTTPMethod.Get) {
       return null
     }
 


### PR DESCRIPTION
🎉 Thanks for sending this pull request! 🎉

Temp fix for: https://github.com/netlify/pod-dev-foundations/issues/592
Currently, if we hit Cloudfront with a nonexisting blob storage key it returns a wrong status code.
Instead of providing a 404 (Not found), it returns a 403 (Access denied).

This is not ideal, we are using the status code to determine if it should throw or not. A 404 just returns null which means nothing found but all fine.

This fix makes it behave similar on a build plugin or during request time