### PR TITLE
chore: cleanup unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,17 +8,14 @@
       "name": "@netlify/blobs",
       "version": "2.1.0",
       "license": "MIT",
-      "dependencies": {
-        "p-map": "^6.0.0"
-      },
       "devDependencies": {
         "@commitlint/cli": "^17.0.0",
         "@commitlint/config-conventional": "^17.0.0",
         "@netlify/eslint-config-node": "^7.0.1",
         "c8": "^7.11.0",
-        "esbuild": "^0.19.0",
         "husky": "^8.0.0",
         "node-fetch": "^3.3.1",
+        "p-map": "^6.0.0",
         "semver": "^7.5.3",
         "tmp-promise": "^3.0.3",
         "tsup": "^7.2.0",
@@ -798,6 +795,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -814,6 +812,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -830,6 +829,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -846,6 +846,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -862,6 +863,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -878,6 +880,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -894,6 +897,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -910,6 +914,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -926,6 +931,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -942,6 +948,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -958,6 +965,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -974,6 +982,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -990,6 +999,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1006,6 +1016,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1022,6 +1033,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1038,6 +1050,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1054,6 +1067,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1070,6 +1084,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1086,6 +1101,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1102,6 +1118,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1118,6 +1135,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1134,6 +1152,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3296,6 +3315,7 @@
       "integrity": "sha512-x7jL0tbRRpv4QUyuDMjONtWFciygUxWaUM1kMX2zWxI0X2YWOt7MSA0g4UdeSiHM8fcYVzpQhKYOycZwxTdZkA==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6456,6 +6476,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
       "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==",
+      "dev": true,
       "engines": {
         "node": ">=16"
       },
@@ -9915,154 +9936,176 @@
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.4.tgz",
       "integrity": "sha512-uBIbiYMeSsy2U0XQoOGVVcpIktjLMEKa7ryz2RLr7L/vTnANNEsPVAh4xOv7ondGz6ac1zVb0F8Jx20rQikffQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/android-arm64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.4.tgz",
       "integrity": "sha512-mRsi2vJsk4Bx/AFsNBqOH2fqedxn5L/moT58xgg51DjX1la64Z3Npicut2VbhvDFO26qjWtPMsVxCd80YTFVeg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/android-x64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.4.tgz",
       "integrity": "sha512-4iPufZ1TMOD3oBlGFqHXBpa3KFT46aLl6Vy7gwed0ZSYgHaZ/mihbYb4t7Z9etjkC9Al3ZYIoOaHrU60gcMy7g==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/darwin-arm64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.4.tgz",
       "integrity": "sha512-Lviw8EzxsVQKpbS+rSt6/6zjn9ashUZ7Tbuvc2YENgRl0yZTktGlachZ9KMJUsVjZEGFVu336kl5lBgDN6PmpA==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/darwin-x64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.4.tgz",
       "integrity": "sha512-YHbSFlLgDwglFn0lAO3Zsdrife9jcQXQhgRp77YiTDja23FrC2uwnhXMNkAucthsf+Psr7sTwYEryxz6FPAVqw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/freebsd-arm64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.4.tgz",
       "integrity": "sha512-vz59ijyrTG22Hshaj620e5yhs2dU1WJy723ofc+KUgxVCM6zxQESmWdMuVmUzxtGqtj5heHyB44PjV/HKsEmuQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/freebsd-x64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.4.tgz",
       "integrity": "sha512-3sRbQ6W5kAiVQRBWREGJNd1YE7OgzS0AmOGjDmX/qZZecq8NFlQsQH0IfXjjmD0XtUYqr64e0EKNFjMUlPL3Cw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/linux-arm": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.4.tgz",
       "integrity": "sha512-z/4ArqOo9EImzTi4b6Vq+pthLnepFzJ92BnofU1jgNlcVb+UqynVFdoXMCFreTK7FdhqAzH0vmdwW5373Hm9pg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/linux-arm64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.4.tgz",
       "integrity": "sha512-ZWmWORaPbsPwmyu7eIEATFlaqm0QGt+joRE9sKcnVUG3oBbr/KYdNE2TnkzdQwX6EDRdg/x8Q4EZQTXoClUqqA==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/linux-ia32": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.4.tgz",
       "integrity": "sha512-EGc4vYM7i1GRUIMqRZNCTzJh25MHePYsnQfKDexD8uPTCm9mK56NIL04LUfX2aaJ+C9vyEp2fJ7jbqFEYgO9lQ==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/linux-loong64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.4.tgz",
       "integrity": "sha512-WVhIKO26kmm8lPmNrUikxSpXcgd6HDog0cx12BUfA2PkmURHSgx9G6vA19lrlQOMw+UjMZ+l3PpbtzffCxFDRg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/linux-mips64el": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.4.tgz",
       "integrity": "sha512-keYY+Hlj5w86hNp5JJPuZNbvW4jql7c1eXdBUHIJGTeN/+0QFutU3GrS+c27L+NTmzi73yhtojHk+lr2+502Mw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/linux-ppc64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.4.tgz",
       "integrity": "sha512-tQ92n0WMXyEsCH4m32S21fND8VxNiVazUbU4IUGVXQpWiaAxOBvtOtbEt3cXIV3GEBydYsY8pyeRMJx9kn3rvw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/linux-riscv64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.4.tgz",
       "integrity": "sha512-tRRBey6fG9tqGH6V75xH3lFPpj9E8BH+N+zjSUCnFOX93kEzqS0WdyJHkta/mmJHn7MBaa++9P4ARiU4ykjhig==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/linux-s390x": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.4.tgz",
       "integrity": "sha512-152aLpQqKZYhThiJ+uAM4PcuLCAOxDsCekIbnGzPKVBRUDlgaaAfaUl5NYkB1hgY6WN4sPkejxKlANgVcGl9Qg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/linux-x64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.4.tgz",
       "integrity": "sha512-Mi4aNA3rz1BNFtB7aGadMD0MavmzuuXNTaYL6/uiYIs08U7YMPETpgNn5oue3ICr+inKwItOwSsJDYkrE9ekVg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/netbsd-x64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.4.tgz",
       "integrity": "sha512-9+Wxx1i5N/CYo505CTT7T+ix4lVzEdz0uCoYGxM5JDVlP2YdDC1Bdz+Khv6IbqmisT0Si928eAxbmGkcbiuM/A==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/openbsd-x64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.4.tgz",
       "integrity": "sha512-MFsHleM5/rWRW9EivFssop+OulYVUoVcqkyOkjiynKBCGBj9Lihl7kh9IzrreDyXa4sNkquei5/DTP4uCk25xw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/sunos-x64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.4.tgz",
       "integrity": "sha512-6Xq8SpK46yLvrGxjp6HftkDwPP49puU4OF0hEL4dTxqCbfx09LyrbUj/D7tmIRMj5D5FCUPksBbxyQhp8tmHzw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/win32-arm64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.4.tgz",
       "integrity": "sha512-PkIl7Jq4mP6ke7QKwyg4fD4Xvn8PXisagV/+HntWoDEdmerB2LTukRZg728Yd1Fj+LuEX75t/hKXE2Ppk8Hh1w==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/win32-ia32": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.4.tgz",
       "integrity": "sha512-ga676Hnvw7/ycdKB53qPusvsKdwrWzEyJ+AtItHGoARszIqvjffTwaaW3b2L6l90i7MO9i+dlAW415INuRhSGg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@esbuild/win32-x64": {
       "version": "0.19.4",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.4.tgz",
       "integrity": "sha512-HP0GDNla1T3ZL8Ko/SHAS2GgtjOg+VmWnnYLhuTksr++EnduYB0f3Y2LzHsUwb2iQ13JGoY6G3R8h6Du/WG6uA==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -11596,6 +11639,7 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.4.tgz",
       "integrity": "sha512-x7jL0tbRRpv4QUyuDMjONtWFciygUxWaUM1kMX2zWxI0X2YWOt7MSA0g4UdeSiHM8fcYVzpQhKYOycZwxTdZkA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@esbuild/android-arm": "0.19.4",
         "@esbuild/android-arm64": "0.19.4",
@@ -13869,7 +13913,8 @@
     "p-map": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
-      "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw=="
+      "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==",
+      "dev": true
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@commitlint/config-conventional": "^17.0.0",
     "@netlify/eslint-config-node": "^7.0.1",
     "c8": "^7.11.0",
-    "esbuild": "^0.19.0",
     "husky": "^8.0.0",
     "node-fetch": "^3.3.1",
     "p-map": "^6.0.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,6 @@
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-  esbuild: {
-    target: 'esnext',
-  },
   test: {
     include: ['src/**/*.test.ts'],
     testTimeout: 30_000,


### PR DESCRIPTION
🎉 Thanks for sending this pull request! 🎉

As we removed esbuild in #59 and replaced it with `tsup` – a package bundler that emit types in the correct format as well, I forgot to remove the dev dependency on esbuild.

This PR is a follow up cleaning up the unused dependency.