### PR TITLE
fix: adjust export map to be actually importable

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,15 +13,15 @@
     ".": {
       "require": {
         "types": "./dist/main.d.cts",
-        "path": "./dist/main.cjs"
+        "default": "./dist/main.cjs"
       },
       "import": {
         "types": "./dist/main.d.ts",
-        "path": "./dist/main.js"
+        "default": "./dist/main.js"
       },
       "default": {
         "types": "./dist/main.d.ts",
-        "path": "./dist/main.js"
+        "default": "./dist/main.js"
       }
     }
   },


### PR DESCRIPTION
**Which problem is this pull request solving?**

With current export map I am unable to actually import from `@netlify/blobs`. Both CJS and ESM ( https://gist.github.com/pieh/273d2341d3623a55b33069260e6fdaac ) are failing with
```
> node test.mjs
node:internal/errors:497
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /Users/misiek/test/netliblob-test/node_modules/@netlify/blobs/package.json imported from /Users/misiek/test/netliblob-test/test.mjs
    at new NodeError (node:internal/errors:406:5)
    at exportsNotFound (node:internal/modules/esm/resolve:268:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:542:13)
    at packageResolve (node:internal/modules/esm/resolve:772:14)
    at moduleResolve (node:internal/modules/esm/resolve:838:20)
    at defaultResolve (node:internal/modules/esm/resolve:1043:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:383:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:352:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:228:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:85:39) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}

Node.js v20.8.0
```

**Describe the solution you've chosen**

Following https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

**Describe alternatives you've considered**

Using following export map
```
  "exports": {
    ".": {
      "require": "./dist/main.cjs",
      "import": "./dist/main.js",
      "default": "./dist/main.js",
      "types": "./dist/main.d.ts"
    }
  },
```

but it was sharing types, which while should be exactly the same, approach in PR seems safer

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
