### PR TITLE
fix: couple of small fixes

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1100,4 +1100,24 @@ describe(`getStore`, () => {
       }),
     ).toThrowError(MissingBlobsEnvironmentError)
   })
+
+  test('Throws when the name of the store is not provided', async () => {
+    const { fetch } = new MockFetch()
+
+    globalThis.fetch = fetch
+
+    // @ts-expect-error Ignoring types, which expect an argument
+    expect(() => getStore()).toThrowError(
+      'The `getStore` method requires the name of the store as a string or as the `name` property of an options object',
+    )
+
+    expect(() =>
+      getStore({
+        token: apiToken,
+        siteID,
+      }),
+    ).toThrowError(
+      'The `getStore` method requires the name of the store as a string or as the `name` property of an options object',
+    )
+  })
 })

--- a/src/store_factory.ts
+++ b/src/store_factory.ts
@@ -44,7 +44,7 @@ export const getStore: {
     return new Store({ client, name: input })
   }
 
-  if (typeof input.name === 'string') {
+  if (typeof input?.name === 'string') {
     const { name } = input
     const clientOptions = getClientOptions(input)
 
@@ -57,7 +57,7 @@ export const getStore: {
     return new Store({ client, name })
   }
 
-  if (typeof input.deployID === 'string') {
+  if (typeof input?.deployID === 'string') {
     const clientOptions = getClientOptions(input)
     const { deployID } = input
 
@@ -70,5 +70,7 @@ export const getStore: {
     return new Store({ client, deployID })
   }
 
-  throw new Error('`getStore()` requires a `name` or `siteID` properties.')
+  throw new Error(
+    'The `getStore` method requires the name of the store as a string or as the `name` property of an options object',
+  )
 }


### PR DESCRIPTION
Fixes two small issues (in separate commits):

- `getDeployStore()` now accepts a `deployID` option, which is useful when the context is not present in the environment (e.g. at build time)
- `getStore()` now throws an error with a friendly message when a store name is not supplied