### PR TITLE
feat: load context from global variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ Rather than explicitly passing the configuration context to the `getStore` metho
 environment. This is particularly useful for setups where the configuration data is held by one system and the data
 needs to be accessed in another system, with no direct communication between the two.
 
-To do this, the system that holds the configuration data should set an environment variable called
-`NETLIFY_BLOBS_CONTEXT` with a Base64-encoded, JSON-stringified representation of an object with the following
-properties:
+To do this, the system that holds the configuration data should set a global variable called `netlifyBlobsContext` or an
+environment variable called `NETLIFY_BLOBS_CONTEXT` with a Base64-encoded, JSON-stringified representation of an object
+with the following properties:
 
 - `apiURL` (optional) or `edgeURL`: URL of the Netlify API (for [API access](#api-access)) or the edge endpoint (for
   [Edge access](#edge-access))

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,14 +1,12 @@
 import { Buffer } from 'node:buffer'
 import { env } from 'node:process'
 
-/**
- * The name of the environment variable that holds the context in a Base64,
- * JSON-encoded object. If we ever need to change the encoding or the shape
- * of this object, we should bump the version and create a new variable, so
- * that the client knows how to consume the data and can advise the user to
- * update the client if needed.
- */
-const NETLIFY_CONTEXT_VARIABLE = 'NETLIFY_BLOBS_CONTEXT'
+declare global {
+  // Using `var` so that the declaration is hoisted in such a way that we can
+  // reference it before it's initialized.
+  // eslint-disable-next-line no-var
+  var netlifyBlobsContext: unknown
+}
 
 /**
  * The context object that we expect in the environment.
@@ -22,11 +20,13 @@ export interface EnvironmentContext {
 }
 
 export const getEnvironmentContext = (): EnvironmentContext => {
-  if (!env[NETLIFY_CONTEXT_VARIABLE]) {
+  const context = globalThis.netlifyBlobsContext || env.NETLIFY_BLOBS_CONTEXT
+
+  if (typeof context !== 'string' || !context) {
     return {}
   }
 
-  const data = Buffer.from(env[NETLIFY_CONTEXT_VARIABLE], 'base64').toString()
+  const data = Buffer.from(context, 'base64').toString()
 
   try {
     return JSON.parse(data) as EnvironmentContext


### PR DESCRIPTION
**Which problem is this pull request solving?**

Currently, the client is loading the context from an environment variable called `NETLIFY_BLOBS_CONTEXT`, so both serverless functions and edge functions need to set the updated context on each request, by setting `process.env.NETLIFY_BLOBS_CONTEXT` in Node.js and by calling `Deno.env.set()` in Deno.

I wanted to see if there was any performance penalty in calling `Deno.env.set()` versus just setting a global variable, so I ran this benchmark and ran it a few times:

```ts
Deno.bench("Environment variable", { group: "timing", baseline: true }, () => {
  for (let i = 0; i < 50_000; i++) {
    Deno.env.set("SOME_VAR", `foo${i}`);
  }
});

Deno.bench("Global variable", { group: "timing" }, () => {
  for (let i = 0; i < 50_000; i++) {
    // @ts-expect-error No types for global variable
    globalThis.someVar = `foo${i}`;
  }
});
```

These are the results I'm seeing:

```
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
runtime: deno 1.35.1 (x86_64-apple-darwin)

file:///Users/eduardoboucas/Sites/tests/deno-bench/index.ts
benchmark                 time (avg)             (min … max)       p75       p99      p995
------------------------------------------------------------ -----------------------------
Environment variable      43.42 ms/iter     (39.8 ms … 52.1 ms)  43.95 ms   52.1 ms   52.1 ms
Global variable               2 ms/iter     (1.68 ms … 3.34 ms)   2.13 ms      3 ms   3.09 ms

summary
  Environment variable
   21.72x slower than Global variable
```

I'm consistently seeing the environment variable set being ~20x slower than the global variable equivalent. In an environment where every millisecond counts, I think we should try to optimise this as best as we can.

So in this PR I'm making it possible for the client to read the context from a `netlifyBlobsContext` environment variable before trying to read it from an environment variable.