### PR TITLE
fix: delete status code checking

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -81,7 +81,7 @@ export class Store {
   async delete(key: string) {
     const res = await this.client.makeRequest({ key, method: HTTPMethod.DELETE, storeName: this.name })
 
-    if (res.status !== 200 && res.status !== 404) {
+    if (res.status !== 200 && res.status !== 204 && res.status !== 404) {
       throw new BlobsInternalError(res.status)
     }
   }


### PR DESCRIPTION
When deleting via the edge, a successful status code is `204`. We weren't classifying this as successful and throwing errors like: 

> Nov 6, 10:20:08 PM: cc534af9 ERROR  Invoke Error 	{"errorType":"BlobsInternalError","errorMessage":"Netlify Blobs has generated an internal error: 204 response","name":"BlobsInternalError","stack":["BlobsInternalError: Netlify Blobs has generated an internal error: 204 response","    at _Store.delete (/var/task/node_modules/@netlify/blobs/dist/main.cjs:263:13)","    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)","    at async Object.netliblob_default (/var/task/functions/netliblob.cjs:51:7)","    at async Runtime.handler (file:///var/task/___netlify-bootstrap.mjs:1847:15)","    at async Runtime.handleOnceStreaming (file:///var/runtime/index.mjs:1206:26)"]}

Here's the [docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html#API_DeleteObject_ResponseSyntax). 