### PR TITLE
feat!: disallow setting an object as a stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ const blob = await store.getMetadata('some-key')
 console.log(blob.etag, blob.metadata)
 ```
 
-### `set(key: string, value: ArrayBuffer | Blob | ReadableStream | string, { metadata?: object }): Promise<void>`
+### `set(key: string, value: ArrayBuffer | Blob | string, { metadata?: object }): Promise<void>`
 
 Creates an object with the given key and value.
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type BlobInput = ReadableStream | string | ArrayBuffer | Blob
+export type BlobInput = string | ArrayBuffer | Blob
 
 export type Fetcher = typeof globalThis.fetch
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

S3 doesn't support uploads with `transfer-encoding: chunked`, so we can't really accept a stream as the input to a `set()` call without buffering the data in the client.

Removing this option for now until we have a better solution.

Part of https://github.com/netlify/pillar-runtime/issues/775.