### PR TITLE
feat!: return boolean from `delete()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ await store.setJSON('some-key', {
 
 ### `delete(key: string): Promise<void>`
 
-Deletes an object with the given key, if one exists.
+If an entry exists with the given key, deletes it and returns `true`. If not, `false` is returned.
 
 ```javascript
 await store.delete('my-key')

--- a/src/store.ts
+++ b/src/store.ts
@@ -78,11 +78,19 @@ export class Store {
     }
   }
 
-  async delete(key: string) {
+  async delete(key: string): Promise<boolean> {
     const res = await this.client.makeRequest({ key, method: HTTPMethod.DELETE, storeName: this.name })
 
-    if (res.status !== 200 && res.status !== 204 && res.status !== 404) {
-      throw new BlobsInternalError(res.status)
+    switch (res.status) {
+      case 200:
+      case 202:
+        return true
+
+      case 404:
+        return false
+
+      default:
+        throw new BlobsInternalError(res.status)
     }
   }
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

Changes the return value of the `delete()` method to be a boolean indicating whether a blob was actually deleted.