### PR TITLE
feat!: remove `fresh` property from metadata result

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ const cachedETag = getFromMockCache('my-key')
 
 // Get entry from the blob store only if its ETag is different from the one you
 // have locally, which means the entry has changed since you last obtained it
-const { data, etag, fresh } = await store.getWithMetadata('some-key', { etag: cachedETag })
+const { data, etag } = await store.getWithMetadata('some-key', { etag: cachedETag })
 
-if (fresh) {
+if (etag === cachedETag) {
   // `data` is `null` because the local blob is fresh
 } else {
   // `data` contains the new blob, store it locally alongside the new ETag

--- a/src/store.ts
+++ b/src/store.ts
@@ -26,7 +26,6 @@ interface GetWithMetadataOptions {
 
 interface GetWithMetadataResult {
   etag?: string
-  fresh: boolean
   metadata: Metadata
 }
 
@@ -219,12 +218,11 @@ export class Store {
     const metadata = getMetadataFromResponse(res)
     const result: GetWithMetadataResult = {
       etag: responseETag,
-      fresh: false,
       metadata,
     }
 
     if (res.status === 304 && requestETag) {
-      return { data: null, ...result, fresh: true }
+      return { data: null, ...result }
     }
 
     if (type === undefined || type === 'text') {


### PR DESCRIPTION
**Which problem is this pull request solving?**

Removes the `fresh` property from the output of `getWithMetadata()` since it's redundant. To know whether a cached entry is fresh or stale, users can compare the value of the `etag` property they send with the `etag` property we return.