### PR TITLE
fix: trailing slash for edge list call

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -62,7 +62,7 @@ export class Client {
         headers[METADATA_HEADER_INTERNAL] = encodedMetadata
       }
 
-      const path = key ? `/${this.siteID}/${storeName}/${key}` : `/${this.siteID}/${storeName}`
+      const path = key ? `/${this.siteID}/${storeName}/${key}` : `/${this.siteID}/${storeName}/`
       const url = new URL(path, this.edgeURL)
 
       for (const key in parameters) {

--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -350,7 +350,7 @@ describe('list', () => {
               next_cursor: 'cursor_1',
             }),
           ),
-          url: `${edgeURL}/${siteID}/${storeName}`,
+          url: `${edgeURL}/${siteID}/${storeName}/`,
         })
         .get({
           headers: { authorization: `Bearer ${edgeToken}` },
@@ -374,7 +374,7 @@ describe('list', () => {
               next_cursor: 'cursor_2',
             }),
           ),
-          url: `${edgeURL}/${siteID}/${storeName}?cursor=cursor_1`,
+          url: `${edgeURL}/${siteID}/${storeName}/?cursor=cursor_1`,
         })
         .get({
           headers: { authorization: `Bearer ${edgeToken}` },
@@ -391,7 +391,7 @@ describe('list', () => {
               directories: ['dir3'],
             }),
           ),
-          url: `${edgeURL}/${siteID}/${storeName}?cursor=cursor_2`,
+          url: `${edgeURL}/${siteID}/${storeName}/?cursor=cursor_2`,
         })
         .get({
           headers: { authorization: `Bearer ${edgeToken}` },
@@ -408,7 +408,7 @@ describe('list', () => {
               directories: [],
             }),
           ),
-          url: `${edgeURL}/${siteID}/${storeName}?prefix=dir2%2F`,
+          url: `${edgeURL}/${siteID}/${storeName}/?prefix=dir2%2F`,
         })
 
       globalThis.fetch = mockStore.fetch
@@ -467,7 +467,7 @@ describe('list', () => {
               next_cursor: 'cursor_1',
             }),
           ),
-          url: `${edgeURL}/${siteID}/${storeName}?directories=true`,
+          url: `${edgeURL}/${siteID}/${storeName}/?directories=true`,
         })
         .get({
           headers: { authorization: `Bearer ${edgeToken}` },
@@ -491,7 +491,7 @@ describe('list', () => {
               next_cursor: 'cursor_2',
             }),
           ),
-          url: `${edgeURL}/${siteID}/${storeName}?cursor=cursor_1&directories=true`,
+          url: `${edgeURL}/${siteID}/${storeName}/?cursor=cursor_1&directories=true`,
         })
         .get({
           headers: { authorization: `Bearer ${edgeToken}` },
@@ -508,7 +508,7 @@ describe('list', () => {
               directories: ['dir3'],
             }),
           ),
-          url: `${edgeURL}/${siteID}/${storeName}?cursor=cursor_2&directories=true`,
+          url: `${edgeURL}/${siteID}/${storeName}/?cursor=cursor_2&directories=true`,
         })
         .get({
           headers: { authorization: `Bearer ${edgeToken}` },
@@ -525,7 +525,7 @@ describe('list', () => {
               directories: [],
             }),
           ),
-          url: `${edgeURL}/${siteID}/${storeName}?prefix=dir2%2F&directories=true`,
+          url: `${edgeURL}/${siteID}/${storeName}/?prefix=dir2%2F&directories=true`,
         })
 
       globalThis.fetch = mockStore.fetch
@@ -578,7 +578,7 @@ describe('list', () => {
             ],
           }),
         ),
-        url: `${edgeURL}/${siteID}/${storeName}?prefix=group%2F`,
+        url: `${edgeURL}/${siteID}/${storeName}/?prefix=group%2F`,
       })
 
       globalThis.fetch = mockStore.fetch
@@ -623,7 +623,7 @@ describe('list', () => {
             next_cursor: 'cursor_2',
           }),
         ),
-        url: `${edgeURL}/${siteID}/${storeName}?cursor=cursor_1`,
+        url: `${edgeURL}/${siteID}/${storeName}/?cursor=cursor_1`,
       })
 
       globalThis.fetch = mockStore.fetch


### PR DESCRIPTION
Due to how we are pattern matching in cloudfront, LIST calls that are being proxied back to the netlify API need to have a trailing `/`. 

This PR adds this trailing slash. 

Closes https://github.com/netlify/pillar-runtime/issues/776