### PR TITLE
fix: stop logging metadata not found error

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -135,7 +135,9 @@ export class BlobsServer {
         headers[METADATA_HEADER_INTERNAL] = encodedMetadata
       }
     } catch (error) {
-      this.logDebug('Could not read metadata file:', error)
+      if (!isNodeError(error) || error.code !== 'ENOENT') {
+        this.logDebug('Could not read metadata file:', error)
+      }
     }
 
     for (const name in headers) {


### PR DESCRIPTION
**Which problem is this pull request solving?**

When the local server fails to find a metadata file for an entry, it shouldn't log it as an error.