### PR TITLE
fix: copy temp file to prevent `EXDEV: cross-device link not permitted`

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -279,7 +279,7 @@ export class BlobsServer {
       })
 
       await fs.mkdir(dirname(dataPath), { recursive: true })
-      await fs.rename(tempDataPath, dataPath)
+      await fs.copyFile(tempDataPath, dataPath)
       await fs.rm(tempDirectory, { force: true, recursive: true })
 
       await fs.mkdir(dirname(metadataPath), { recursive: true })


### PR DESCRIPTION
Some users are seeing this error:

```
[Netlify Blobs server] Error when writing data: [Error: EXDEV: cross-device link not permitted, rename '/tmp/netlify-blobsLCv61H/entries/7a7c9eec-3514-426a-bea9-3f7e7f659808/... -> '/run/media/.../site/.netlify/blobs-serves/entries/7a7c9eec-3514-426a-bea9-3f7e7f659808/...'] {
  errno: -18,
  code: 'EXDEV',
  syscall: 'rename',
  path: 'redacted',
  dest: 'redacted'
}
```

According to https://stackoverflow.com/questions/43206198/what-does-the-exdev-cross-device-link-not-permitted-error-mean, this happens when a file is renamed across two different partitions of a disk, which can definitely happen on dev machines we don't have control over. It mentions that a good fix is to copy & remove instead - that's what this PR does.

Resolves https://linear.app/netlify/issue/COM-227/reported-issue-using-blobs-from-netlify-dev.