### PR TITLE
fix: disallow empty key

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -781,6 +781,7 @@ describe('set', () => {
         siteID,
       })
 
+      expect(async () => await blobs.set('', 'value')).rejects.toThrowError('Blob key must not be empty.')
       expect(async () => await blobs.set('/key', 'value')).rejects.toThrowError(
         'Blob key must not start with forward slash (/).',
       )

--- a/src/store.ts
+++ b/src/store.ts
@@ -307,6 +307,10 @@ export class Store {
   }
 
   private static validateKey(key: string) {
+    if (key === '') {
+      throw new Error('Blob key must not be empty.')
+    }
+
     if (key.startsWith('/') || key.startsWith('%2F')) {
       throw new Error('Blob key must not start with forward slash (/).')
     }


### PR DESCRIPTION
Disallows `""` as key. This is not a breaking change, because before we had a bug where `get("")` would show the result of `list()` - so this didn't work in the first place.

Resolves https://linear.app/netlify/issue/COM-283/blobs-get-shows-unintended-api-response.