### PR TITLE
chore(types): start comprehensive typing

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -781,7 +781,9 @@ describe('set', () => {
         siteID,
       })
 
+      // @ts-expect-error The `key` paramater is typed to not allow this
       expect(async () => await blobs.set('', 'value')).rejects.toThrowError('Blob key must not be empty.')
+      // @ts-expect-error The `key` paramater is typed to not allow this
       expect(async () => await blobs.set('/key', 'value')).rejects.toThrowError(
         'Blob key must not start with forward slash (/).',
       )

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,6 +19,7 @@ interface NamedStoreOptions extends BaseStoreOptions {
 }
 
 export type StoreOptions = DeployStoreOptions | NamedStoreOptions
+type Key<T> = T extends string ? (T extends '' | `/${string}` ? never : T) : never
 
 export interface GetWithMetadataOptions {
   etag?: string
@@ -257,7 +258,7 @@ export class Store {
     )
   }
 
-  async set(key: string, data: BlobInput, { metadata }: SetOptions = {}) {
+  async set<K>(key: Key<K>, data: BlobInput, { metadata }: SetOptions = {}) {
     Store.validateKey(key)
 
     const res = await this.client.makeRequest({
@@ -273,7 +274,7 @@ export class Store {
     }
   }
 
-  async setJSON(key: string, data: unknown, { metadata }: SetOptions = {}) {
+  async setJSON<K>(key: Key<K>, data: unknown, { metadata }: SetOptions = {}) {
     Store.validateKey(key)
 
     const payload = JSON.stringify(data)
@@ -306,7 +307,7 @@ export class Store {
     }
   }
 
-  private static validateKey(key: string) {
+  private static validateKey<K>(key: Key<K>) {
     if (key === '') {
       throw new Error('Blob key must not be empty.')
     }


### PR DESCRIPTION
**Which problem is this pull request solving?**

The type signatures could be improved to provide static checks to our typescript users that supplement our runtime checks.

**List other issues or pull requests related to this problem**

Noticed with https://github.com/netlify/blobs/pull/134

**Describe the solution you've chosen**

#134 disallows empty keys in the `set` functions at runtime, but I chose to infer what's passed in to those and disallow `''` and strings that start with `/` at the type level.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.

**A picture of a cute animal (not mandatory but encouraged)**

![Happy Golden Retriever - RoBjhqlygXkCtgsWe6](https://github.com/netlify/blobs/assets/1126370/2d77a7ef-12af-451f-a39d-4dc3c1967b6b)
