### PR TITLE
fix: simplify streaming of server writes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import http from 'node:http'
 import { tmpdir } from 'node:os'
 import { dirname, join, relative, resolve, sep } from 'node:path'
 import { platform } from 'node:process'
+import { promises as stream } from 'node:stream'
 
 import { ListResponse } from './backend/list.ts'
 import { decodeMetadata, encodeMetadata, METADATA_HEADER_INTERNAL } from './metadata.ts'
@@ -271,12 +272,7 @@ export class BlobsServer {
       const tempDataPath = join(tempDirectory, relativeDataPath)
 
       await fs.mkdir(dirname(tempDataPath), { recursive: true })
-
-      await new Promise((resolve, reject) => {
-        req.pipe(createWriteStream(tempDataPath))
-        req.on('end', resolve)
-        req.on('error', reject)
-      })
+      await stream.pipeline(req, createWriteStream(tempDataPath))
 
       await fs.mkdir(dirname(dataPath), { recursive: true })
       await fs.copyFile(tempDataPath, dataPath)


### PR DESCRIPTION
**Which problem is this pull request solving?**

We've seen some intermittent failures when handling `set()` calls in the Blobs server, where we seem to write a zero-bytes file to the final location.

This PR attempts to solve that by simplifying the logic for handling the streaming of these requests, replacing `pipe()` with the better `pipeline()`.