### PR TITLE
feat: use `accept` header for signed URL

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -134,7 +134,10 @@ export class Client {
       }
     }
 
-    const res = await this.fetch(url.toString(), { headers: apiHeaders, method })
+    const res = await this.fetch(url.toString(), {
+      headers: { ...apiHeaders, accept: `application/json;type=signed-url` },
+      method,
+    })
 
     if (res.status !== 200) {
       throw new Error(`Netlify Blobs has generated an internal error: ${res.status} response`)

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -45,7 +45,7 @@ describe('get', () => {
     test('Reads from the blob store', async () => {
       const mockStore = new MockFetch()
         .get({
-          headers: { authorization: `Bearer ${apiToken}` },
+          headers: { accept: 'application/json;type=signed-url', authorization: `Bearer ${apiToken}` },
           response: new Response(JSON.stringify({ url: signedURL })),
           url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
         })
@@ -54,7 +54,7 @@ describe('get', () => {
           url: signedURL,
         })
         .get({
-          headers: { authorization: `Bearer ${apiToken}` },
+          headers: { accept: 'application/json;type=signed-url', authorization: `Bearer ${apiToken}` },
           response: new Response(JSON.stringify({ url: signedURL })),
           url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
         })
@@ -63,7 +63,7 @@ describe('get', () => {
           url: signedURL,
         })
         .get({
-          headers: { authorization: `Bearer ${apiToken}` },
+          headers: { accept: 'application/json;type=signed-url', authorization: `Bearer ${apiToken}` },
           response: new Response(JSON.stringify({ url: signedURL })),
           url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${complexKey}`,
         })
@@ -95,7 +95,7 @@ describe('get', () => {
     test('Returns `null` when the pre-signed URL returns a 404', async () => {
       const mockStore = new MockFetch()
         .get({
-          headers: { authorization: `Bearer ${apiToken}` },
+          headers: { accept: 'application/json;type=signed-url', authorization: `Bearer ${apiToken}` },
           response: new Response(JSON.stringify({ url: signedURL })),
           url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
         })
@@ -118,7 +118,7 @@ describe('get', () => {
 
     test('Throws when the API returns a non-200 status code', async () => {
       const mockStore = new MockFetch().get({
-        headers: { authorization: `Bearer ${apiToken}` },
+        headers: { accept: 'application/json;type=signed-url', authorization: `Bearer ${apiToken}` },
         response: new Response(null, { status: 401 }),
         url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
       })
@@ -140,7 +140,7 @@ describe('get', () => {
     test('Throws when a pre-signed URL returns a non-200 status code', async () => {
       const mockStore = new MockFetch()
         .get({
-          headers: { authorization: `Bearer ${apiToken}` },
+          headers: { accept: 'application/json;type=signed-url', authorization: `Bearer ${apiToken}` },
           response: new Response(JSON.stringify({ url: signedURL })),
           url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
         })


### PR DESCRIPTION
**Which problem is this pull request solving?**

Follow-up to #147. Sets the right `accept` header to retrieve a signed URL for reads.