### PR TITLE
feat: allow internal access to legacy stores

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -126,8 +126,8 @@ export class Client {
       apiHeaders[METADATA_HEADER_EXTERNAL] = encodedMetadata
     }
 
-    // HEAD requests are implemented directly in the Netlify API.
-    if (method === HTTPMethod.HEAD) {
+    // HEAD and DELETE requests are implemented directly in the Netlify API.
+    if (method === HTTPMethod.HEAD || method === HTTPMethod.DELETE) {
       return {
         headers: apiHeaders,
         url: url.toString(),

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1107,21 +1107,13 @@ describe('delete', () => {
       const mockStore = new MockFetch()
         .delete({
           headers: { authorization: `Bearer ${apiToken}` },
-          response: new Response(JSON.stringify({ url: signedURL })),
+          response: new Response(null, { status: 204 }),
           url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
         })
         .delete({
-          response: new Response(null),
-          url: signedURL,
-        })
-        .delete({
           headers: { authorization: `Bearer ${apiToken}` },
-          response: new Response(JSON.stringify({ url: signedURL })),
+          response: new Response(null, { status: 204 }),
           url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${complexKey}`,
-        })
-        .delete({
-          response: new Response(null),
-          url: signedURL,
         })
 
       globalThis.fetch = mockStore.fetch
@@ -1139,16 +1131,11 @@ describe('delete', () => {
     })
 
     test('Does not throw when the blob does not exist', async () => {
-      const mockStore = new MockFetch()
-        .delete({
-          headers: { authorization: `Bearer ${apiToken}` },
-          response: new Response(JSON.stringify({ url: signedURL })),
-          url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
-        })
-        .delete({
-          response: new Response(null, { status: 404 }),
-          url: signedURL,
-        })
+      const mockStore = new MockFetch().delete({
+        headers: { authorization: `Bearer ${apiToken}` },
+        response: new Response(null, { status: 404 }),
+        url: `https://api.netlify.com/api/v1/blobs/${siteID}/site:production/${key}`,
+      })
 
       globalThis.fetch = mockStore.fetch
 
@@ -1178,7 +1165,7 @@ describe('delete', () => {
         siteID,
       })
 
-      expect(async () => await blobs.delete(key)).rejects.toThrowError(
+      await expect(async () => await blobs.delete(key)).rejects.toThrowError(
         `Netlify Blobs has generated an internal error: 401 response`,
       )
       expect(mockStore.fulfilled).toBeTruthy()

--- a/src/store.ts
+++ b/src/store.ts
@@ -8,6 +8,7 @@ import { BlobInput, HTTPMethod } from './types.ts'
 import { BlobsInternalError, collectIterator } from './util.ts'
 
 export const DEPLOY_STORE_PREFIX = 'deploy:'
+export const LEGACY_STORE_INTERNAL_PREFIX = 'netlify-internal/legacy-namespace/'
 export const SITE_STORE_PREFIX = 'site:'
 
 interface BaseStoreOptions {
@@ -76,6 +77,12 @@ export class Store {
       Store.validateDeployID(options.deployID)
 
       this.name = DEPLOY_STORE_PREFIX + options.deployID
+    } else if (options.name.startsWith(LEGACY_STORE_INTERNAL_PREFIX)) {
+      const storeName = options.name.slice(LEGACY_STORE_INTERNAL_PREFIX.length)
+
+      Store.validateStoreName(storeName)
+
+      this.name = storeName
     } else {
       Store.validateStoreName(options.name)
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

Allows site-scoped stores using the legacy namespace to be access using a special prefix. This is not a customer-facing feature and is meant to be used by Netlify tooling.

**List other issues or pull requests related to this problem**

Part of ADN-370.