### PR TITLE
feat: respect `accept` header in server

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,6 +4,8 @@ import { encodeMetadata, Metadata, METADATA_HEADER_EXTERNAL, METADATA_HEADER_INT
 import { fetchAndRetry } from './retry.ts'
 import { BlobInput, Fetcher, HTTPMethod } from './types.ts'
 
+export const SIGNED_URL_ACCEPT_HEADER = 'application/json;type=signed-url'
+
 interface MakeStoreRequestOptions {
   body?: BlobInput | null
   consistency?: ConsistencyMode
@@ -135,7 +137,7 @@ export class Client {
     }
 
     const res = await this.fetch(url.toString(), {
-      headers: { ...apiHeaders, accept: `application/json;type=signed-url` },
+      headers: { ...apiHeaders, accept: SIGNED_URL_ACCEPT_HEADER },
       method,
     })
 

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -402,14 +402,10 @@ test('Returns a signed URL or the blob directly based on the request parameters'
   // default.
   const res2 = await fetch(`http://localhost:${port}/api/v1/blobs/${siteID}/site:my-store/key-1`, {
     headers: {
-      accept: 'application/json;type=signed-url',
       authorization: `Bearer ${token}`,
     },
   })
-  const { url: url2 } = await res2.json()
-  const data2 = await fetch(url2)
-
-  expect(await data2.text()).toBe(value)
+  expect(await res2.text()).toBe(value)
 
   // When reading through a new API endpoint and requesting a signed URL, we
   // should get one.

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -371,11 +371,9 @@ test('Returns a signed URL or the blob directly based on the request parameters'
   const siteID = '9a003659-aaaa-0000-aaaa-63d3720d8621'
   const token = 'some token'
   const value = 'value 1'
-  const server1Ops: string[] = []
   const directory = await tmp.dir()
   const server = new BlobsServer({
     directory: directory.path,
-    onRequest: ({ type }) => server1Ops.push(type),
     token,
   })
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

This is a follow-up to #147. The new API endpoints can respond to a "get blob" operation by issuing a signed URL or by returning the blob bytes directly. This behaviour is controlled with the `accept` header.

This PR ports that behaviour to the local server.