### PR TITLE
feat!: move server to sub-module export

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -2,7 +2,6 @@
 import { rm } from 'node:fs/promises'
 import { argv } from 'process'
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { build } from 'tsup'
 
 const dist = './dist'
@@ -11,7 +10,7 @@ await rm(dist, { recursive: true, force: true })
 
 /** @type {import('tsup').Options} */
 const options = {
-  entry: ['src/main.ts'],
+  entry: ['src/server.ts', 'src/main.ts'],
   tsconfig: 'tsconfig.json',
   bundle: true,
   dts: true,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,21 @@
         "default": "./dist/main.js"
       }
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./server": {
+      "require": {
+        "types": "./dist/server.d.cts",
+        "default": "./dist/server.cjs"
+      },
+      "import": {
+        "types": "./dist/server.d.ts",
+        "default": "./dist/server.js"
+      },
+      "default": {
+        "types": "./dist/server.d.ts",
+        "default": "./dist/server.js"
+      }
+    }
   },
   "files": [
     "dist/**/*"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     }
   },
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "server.d.ts"
   ],
   "scripts": {
     "build": "run-s build:*",

--- a/server.d.ts
+++ b/server.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/server.d.ts'

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,5 @@
 export { getDeployStore, getStore } from './store_factory.ts'
 export { listStores } from './store_list.ts'
-export { BlobsServer } from './server.ts'
 export type {
   Store,
   StoreOptions,


### PR DESCRIPTION
**Which problem is this pull request solving?**

Moves the local server to a sub-module export. This means that the way the `BlobsServer` class is imported has changed:

```diff
-import { BlobsServer } from "@netlify/blobs"
+import { BlobsServer } from "@netlify/blobs/server"

const server = new BlobsServer()
```