### PR TITLE
fix: include connectLambda in dist

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+export { connectLambda } from './lambda_compat.ts'
 export { getDeployStore, getStore } from './store_factory.ts'
 export { listStores } from './store_list.ts'
 export type {


### PR DESCRIPTION
The NPM package doesn't include the `connectLambda` function causing an error like:

```
✘ [ERROR] No matching export in "node_modules/@netlify/blobs/dist/main.js" for import "connectLambda"

    netlify/functions/api.ts:4:8:
      4 │ import {connectLambda} from '@netlify/blobs'
```

This PR exports that function so it should exist in the package.
