### PR TITLE
feat: add experimental support for region selection

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -58,6 +58,7 @@ export interface EnvironmentContext {
   apiURL?: string
   deployID?: string
   edgeURL?: string
+  primaryRegion?: string
   siteID?: string
   token?: string
   uncachedEdgeURL?: string


### PR DESCRIPTION
**Which problem is this pull request solving?**

Adds experimental support for region selection in Netlify Blobs. Right now, this is limited to deploy-scoped stores and is configured using a new `experimentalRegion` parameter of `getDeployStore`. It can be used as follows:

- If `experimentalRegion` is set to `auto`, it instructs the backend to automatically pick the region that is configured for the deploy
    - This is only supported in our API endpoints, so it's not available when initialising the store with a `edgeURL` property
- If `experimentalRegion` is set to `context`, it tries to load the name of the region from the environment context, throwing an error if not found
- If `experimentalRegion` is unset (or set to anything else), the existing behaviour will be observed

Part of COM-585.