### PR TITLE
feat: export `setEnvironmentContext()`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+export { setEnvironmentContext } from './environment.ts'
 export { connectLambda } from './lambda_compat.ts'
 export { getDeployStore, getStore } from './store_factory.ts'
 export { listStores } from './store_list.ts'


### PR DESCRIPTION
**Which problem is this pull request solving?**

Exports the `setEnvironmentContext()` method, which consumers like Netlify Build can use to populate the Blobs context.