### PR TITLE
feat: handle `region:` prefix in local server

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import { promises as fs } from 'node:fs'
 import { env, version as nodeVersion } from 'node:process'
 
@@ -425,6 +426,36 @@ test('Returns a signed URL or the blob directly based on the request parameters'
   const data3 = await fetch(url3)
 
   expect(await data3.text()).toBe(value)
+
+  await server.stop()
+  await fs.rm(directory.path, { force: true, recursive: true })
+})
+
+test('Accepts stores with `experimentalRegion: "context"`', async () => {
+  const deployID = '655f77a1b48f470008e5879a'
+  const directory = await tmp.dir()
+  const server = new BlobsServer({
+    directory: directory.path,
+    token,
+  })
+  const { port } = await server.start()
+
+  const context = {
+    deployID,
+    edgeURL: `http://localhost:${port}`,
+    primaryRegion: 'us-east-1',
+    siteID,
+    token,
+  }
+
+  env.NETLIFY_BLOBS_CONTEXT = Buffer.from(JSON.stringify(context)).toString('base64')
+
+  const store = getDeployStore({ experimentalRegion: 'context' })
+  const key = 'my-key'
+
+  await store.set(key, 'hello from a deploy store')
+
+  expect(await store.get(key)).toBe('hello from a deploy store')
 
   await server.stop()
   await fs.rm(directory.path, { force: true, recursive: true })

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -452,10 +452,11 @@ test('Accepts stores with `experimentalRegion: "context"`', async () => {
 
   const store = getDeployStore({ experimentalRegion: 'context' })
   const key = 'my-key'
+  const value = 'hello from a deploy store'
 
-  await store.set(key, 'hello from a deploy store')
+  await store.set(key, value)
 
-  expect(await store.get(key)).toBe('hello from a deploy store')
+  expect(await store.get(key)).toBe(value)
 
   await server.stop()
   await fs.rm(directory.path, { force: true, recursive: true })

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -431,7 +431,7 @@ test('Returns a signed URL or the blob directly based on the request parameters'
   await fs.rm(directory.path, { force: true, recursive: true })
 })
 
-test('Accepts stores with `experimentalRegion: "context"`', async () => {
+test('Accepts stores with `experimentalRegion`', async () => {
   const deployID = '655f77a1b48f470008e5879a'
   const directory = await tmp.dir()
   const server = new BlobsServer({

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import { isNodeError, Logger } from './util.ts'
 const API_URL_PATH = /\/api\/v1\/blobs\/(?<site_id>[^/]+)\/(?<store_name>[^/]+)\/?(?<key>[^?]*)/
 const LEGACY_API_URL_PATH = /\/api\/v1\/sites\/(?<site_id>[^/]+)\/blobs\/?(?<key>[^?]*)/
 const LEGACY_DEFAULT_STORE = 'production'
+const REGION_PREFIX = 'region:'
 
 export enum Operation {
   DELETE = 'delete',
@@ -335,7 +336,13 @@ export class BlobsServer {
       return {}
     }
 
-    const [, siteID, rawStoreName, ...key] = url.pathname.split('/')
+    let parts = url.pathname.split('/').slice(1)
+
+    if (parts[0].startsWith(REGION_PREFIX)) {
+      parts = parts.slice(1)
+    }
+
+    const [siteID, rawStoreName, ...key] = parts
 
     if (!siteID) {
       return {}


### PR DESCRIPTION
**Which problem is this pull request solving?**

When using the new `experimentalRegion` property in a deploy-scoped store in conjunction with `edgeURL`, the client will send the region in the URL path with a `region:` prefix. This PR makes the local server understand that and point requests to the right path on disk.