### PR TITLE
feat: support named deploy-scoped stores

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1384,6 +1384,80 @@ describe('Deploy scope', () => {
     expect(mockStore.fulfilled).toBeTruthy()
   })
 
+  test('Returns a named deploy-scoped store if `getDeployStore` receives an object with a `name` property', async () => {
+    const mockToken = 'some-token'
+    const mockStoreName = 'my-store'
+    const mockStore = new MockFetch()
+      .get({
+        headers: { authorization: `Bearer ${mockToken}` },
+        response: new Response(value),
+        url: `${edgeURL}/${siteID}/deploy:${deployID}:${mockStoreName}/${key}`,
+      })
+      .get({
+        headers: { authorization: `Bearer ${mockToken}` },
+        response: new Response(value),
+        url: `${edgeURL}/${siteID}/deploy:${deployID}:${mockStoreName}/${key}`,
+      })
+
+    globalThis.fetch = mockStore.fetch
+
+    const context = {
+      deployID,
+      edgeURL,
+      siteID,
+      token: mockToken,
+    }
+
+    env.NETLIFY_BLOBS_CONTEXT = Buffer.from(JSON.stringify(context)).toString('base64')
+
+    const deployStore = getDeployStore(mockStoreName)
+
+    const string = await deployStore.get(key)
+    expect(string).toBe(value)
+
+    const stream = await deployStore.get(key, { type: 'stream' })
+    expect(await streamToString(stream as unknown as NodeJS.ReadableStream)).toBe(value)
+
+    expect(mockStore.fulfilled).toBeTruthy()
+  })
+
+  test('Returns a named deploy-scoped store if `getDeployStore` receives a string parameter', async () => {
+    const mockToken = 'some-token'
+    const mockStoreName = 'my-store'
+    const mockStore = new MockFetch()
+      .get({
+        headers: { authorization: `Bearer ${mockToken}` },
+        response: new Response(value),
+        url: `${edgeURL}/${siteID}/deploy:${deployID}:${mockStoreName}/${key}`,
+      })
+      .get({
+        headers: { authorization: `Bearer ${mockToken}` },
+        response: new Response(value),
+        url: `${edgeURL}/${siteID}/deploy:${deployID}:${mockStoreName}/${key}`,
+      })
+
+    globalThis.fetch = mockStore.fetch
+
+    const context = {
+      deployID,
+      edgeURL,
+      siteID,
+      token: mockToken,
+    }
+
+    env.NETLIFY_BLOBS_CONTEXT = Buffer.from(JSON.stringify(context)).toString('base64')
+
+    const deployStore = getDeployStore({ name: mockStoreName })
+
+    const string = await deployStore.get(key)
+    expect(string).toBe(value)
+
+    const stream = await deployStore.get(key, { type: 'stream' })
+    expect(await streamToString(stream as unknown as NodeJS.ReadableStream)).toBe(value)
+
+    expect(mockStore.fulfilled).toBeTruthy()
+  })
+
   test('Throws if the deploy ID fails validation', async () => {
     const mockToken = 'some-token'
     const mockStore = new MockFetch()

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1384,7 +1384,7 @@ describe('Deploy scope', () => {
     expect(mockStore.fulfilled).toBeTruthy()
   })
 
-  test('Returns a named deploy-scoped store if `getDeployStore` receives an object with a `name` property', async () => {
+  test('Returns a named deploy-scoped store if `getDeployStore` receives a string parameter', async () => {
     const mockToken = 'some-token'
     const mockStoreName = 'my-store'
     const mockStore = new MockFetch()
@@ -1421,7 +1421,7 @@ describe('Deploy scope', () => {
     expect(mockStore.fulfilled).toBeTruthy()
   })
 
-  test('Returns a named deploy-scoped store if `getDeployStore` receives a string parameter', async () => {
+  test('Returns a named deploy-scoped store if `getDeployStore` receives an object with a `name` property', async () => {
     const mockToken = 'some-token'
     const mockStoreName = 'my-store'
     const mockStore = new MockFetch()

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,6 +16,7 @@ interface BaseStoreOptions {
 
 interface DeployStoreOptions extends BaseStoreOptions {
   deployID: string
+  name?: string
 }
 
 interface NamedStoreOptions extends BaseStoreOptions {
@@ -74,7 +75,13 @@ export class Store {
     if ('deployID' in options) {
       Store.validateDeployID(options.deployID)
 
-      this.name = DEPLOY_STORE_PREFIX + options.deployID
+      let name = DEPLOY_STORE_PREFIX + options.deployID
+
+      if (options.name) {
+        name += `:${options.name}`
+      }
+
+      this.name = name
     } else if (options.name.startsWith(LEGACY_STORE_INTERNAL_PREFIX)) {
       const storeName = options.name.slice(LEGACY_STORE_INTERNAL_PREFIX.length)
 

--- a/src/store_factory.ts
+++ b/src/store_factory.ts
@@ -11,14 +11,16 @@ type ExperimentalRegion =
 
 interface GetDeployStoreOptions extends Partial<ClientOptions> {
   deployID?: string
+  name?: string
   experimentalRegion?: ExperimentalRegion
 }
 
 /**
  * Gets a reference to a deploy-scoped store.
  */
-export const getDeployStore = (options: GetDeployStoreOptions = {}): Store => {
+export const getDeployStore = (input: GetDeployStoreOptions | string = {}): Store => {
   const context = getEnvironmentContext()
+  const options = typeof input === 'string' ? { name: input } : input
   const deployID = options.deployID ?? context.deployID
 
   if (!deployID) {
@@ -47,7 +49,7 @@ export const getDeployStore = (options: GetDeployStoreOptions = {}): Store => {
 
   const client = new Client(clientOptions)
 
-  return new Store({ client, deployID })
+  return new Store({ client, deployID, name: options.name })
 }
 
 interface GetStoreOptions extends Partial<ClientOptions> {


### PR DESCRIPTION
Part of https://linear.app/netlify/issue/ADN-97/extend-getdeploystore-to-accept-a-name.