### PR TITLE
feat!: add region parameter

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
 import { BlobsConsistencyError, ConsistencyMode } from './consistency.ts'
 import { EnvironmentContext, getEnvironmentContext, MissingBlobsEnvironmentError } from './environment.ts'
 import { encodeMetadata, Metadata, METADATA_HEADER_EXTERNAL, METADATA_HEADER_INTERNAL } from './metadata.ts'
+import { InvalidBlobsRegionError, isValidRegion } from './region.ts'
 import { fetchAndRetry } from './retry.ts'
 import { BlobInput, Fetcher, HTTPMethod } from './types.ts'
 import { BlobsInternalError } from './util.ts'
@@ -229,6 +230,10 @@ export const getClientOptions = (
 
   if (!siteID || !token) {
     throw new MissingBlobsEnvironmentError(['siteID', 'token'])
+  }
+
+  if (options.region !== undefined && !isValidRegion(options.region)) {
+    throw new InvalidBlobsRegionError(options.region)
   }
 
   const clientOptions: InternalClientOptions = {

--- a/src/consistency.test.ts
+++ b/src/consistency.test.ts
@@ -152,6 +152,7 @@ describe('Consistency configuration', () => {
       cool: true,
       functions: ['edge', 'serverless'],
     }
+    const mockRegion = 'us-east-1'
     const headers = {
       etag: '123456789',
       'x-amz-meta-user': `b64;${base64Encode(mockMetadata)}`,
@@ -160,17 +161,17 @@ describe('Consistency configuration', () => {
       .get({
         headers: { authorization: `Bearer ${edgeToken}` },
         response: new Response(value),
-        url: `${uncachedEdgeURL}/${siteID}/deploy:${deployID}/${key}`,
+        url: `${uncachedEdgeURL}/region:${mockRegion}/${siteID}/deploy:${deployID}/${key}`,
       })
       .head({
         headers: { authorization: `Bearer ${edgeToken}` },
         response: new Response(null, { headers }),
-        url: `${uncachedEdgeURL}/${siteID}/deploy:${deployID}/${key}`,
+        url: `${uncachedEdgeURL}/region:${mockRegion}/${siteID}/deploy:${deployID}/${key}`,
       })
       .get({
         headers: { authorization: `Bearer ${edgeToken}` },
         response: new Response(value, { headers }),
-        url: `${uncachedEdgeURL}/${siteID}/deploy:${deployID}/${key}`,
+        url: `${uncachedEdgeURL}/region:${mockRegion}/${siteID}/deploy:${deployID}/${key}`,
       })
 
     globalThis.fetch = mockStore.fetch
@@ -179,6 +180,7 @@ describe('Consistency configuration', () => {
       consistency: 'strong',
       edgeURL,
       deployID,
+      region: mockRegion,
       token: edgeToken,
       siteID,
       uncachedEdgeURL,

--- a/src/region.ts
+++ b/src/region.ts
@@ -1,3 +1,5 @@
+export const REGION_AUTO = 'auto'
+
 const regions = {
   'us-east-1': true,
   'us-east-2': true,

--- a/src/region.ts
+++ b/src/region.ts
@@ -1,0 +1,18 @@
+const regions = {
+  'us-east-1': true,
+  'us-east-2': true,
+}
+
+export type Region = keyof typeof regions
+
+export const isValidRegion = (input: string): input is Region => Object.keys(regions).includes(input)
+
+export class InvalidBlobsRegionError extends Error {
+  constructor(region: string) {
+    super(
+      `${region} is not a supported Netlify Blobs region. Supported values are: ${Object.keys(regions).join(', ')}.`,
+    )
+
+    this.name = 'InvalidBlobsRegionError'
+  }
+}

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -306,6 +306,7 @@ test('Works with a deploy-scoped store', async () => {
   const store = getDeployStore({
     deployID,
     edgeURL: `http://localhost:${port}`,
+    region: 'us-east-1',
     token,
     siteID,
   })
@@ -356,6 +357,7 @@ test('Lists site stores', async () => {
   const store3 = getDeployStore({
     deployID: '655f77a1b48f470008e5879a',
     edgeURL: `http://localhost:${port}`,
+    region: 'us-east-1',
     token,
     siteID,
   })
@@ -431,7 +433,7 @@ test('Returns a signed URL or the blob directly based on the request parameters'
   await fs.rm(directory.path, { force: true, recursive: true })
 })
 
-test('Accepts stores with `experimentalRegion`', async () => {
+test('Accepts deploy-scoped stores with the region defined in the context', async () => {
   const deployID = '655f77a1b48f470008e5879a'
   const directory = await tmp.dir()
   const server = new BlobsServer({
@@ -450,7 +452,7 @@ test('Accepts stores with `experimentalRegion`', async () => {
 
   env.NETLIFY_BLOBS_CONTEXT = Buffer.from(JSON.stringify(context)).toString('base64')
 
-  const store = getDeployStore({ experimentalRegion: 'context' })
+  const store = getDeployStore()
   const key = 'my-key'
   const value = 'hello from a deploy store'
 

--- a/src/store_factory.ts
+++ b/src/store_factory.ts
@@ -1,6 +1,6 @@
 import { Client, ClientOptions, getClientOptions } from './client.ts'
 import { getEnvironmentContext, MissingBlobsEnvironmentError } from './environment.ts'
-import { Region } from './region.ts'
+import { Region, REGION_AUTO } from './region.ts'
 import { Store } from './store.ts'
 
 interface GetDeployStoreOptions extends Partial<ClientOptions> {
@@ -38,7 +38,7 @@ export const getDeployStore = (input: GetDeployStoreOptions | string = {}): Stor
     } else {
       // For API requests, we can use `auto` and let the API choose the right
       // region.
-      clientOptions.region = 'auto'
+      clientOptions.region = REGION_AUTO
     }
   }
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

In #158, we've added experimental support for configurable regions to deploy-scoped stores (i.e. stores created with `getDeployStore()`). It works as follows:

- For API calls (i.e. when using an API token), you can use `getDeployStore({ experimentalRegion: "auto" })` to instruct the API to choose the same region as the one configured for functions
  - If this parameter is not supplied, the Blobs client will not send any region parameter to the API, which means the default region will be used
- For edge calls (i.e. when using a token from a serverless function or an edge function), you can use `getDeployStore({ experimentalRegion: "context" })` to instruct the CDN to choose the region defined in the environment
  - If a region is not defined in the environment, an error will be thrown
  - This should not happen, since we're populating the environment with a region in all contexts (serverless functions, edge functions, and the CLI)

This PR introduces the following changes:

- The `experimentalRegion` parameter is removed
- A new `region` parameter is added to the `getDeployStore` method, which takes the name of a region
- For API calls, a region is now always sent to the API
  - If a region has been specified via the `region` parameter, that will be used
  - If not, the client will use `auto`
- For edge calls, a region is now always sent to the CDN
  - If a region has been specified via the `region` parameter, that will be used
  - If not, the region specified in the context will be used, if one is set
  - If not, an error will be thrown

Technically, **this is a breaking change** because `getDeployStore()` now selects the functions region by default instead of the default region, accessing the same store using different versions of the Blobs client might generate different reasons, since they may be pointing to different regions.

Should you want to update your Blobs client but keep accessing a deploy-scoped store that has been created with an older version, you can use `getDeployStore({ region: "us-east-2" })` to ensure you're using the right region.