### PR TITLE
fix: 404ing list results should return empty iterators, not throw

### DIFF
--- a/src/list.test.ts
+++ b/src/list.test.ts
@@ -762,4 +762,58 @@ describe('list', () => {
     expect(directories).toEqual([])
     expect(mockStore.fulfilled).toBeTruthy()
   })
+
+  test('Handles missing content automatic pagination', async () => {
+    const mockStore = new MockFetch().get({
+      headers: { authorization: `Bearer ${edgeToken}` },
+      response: new Response('<not_found>', { status: 404 }),
+      url: `${edgeURL}/${siteID}/site:${storeName}?prefix=group%2F`,
+    })
+
+    globalThis.fetch = mockStore.fetch
+
+    const store = getStore({
+      edgeURL,
+      name: storeName,
+      token: edgeToken,
+      siteID,
+    })
+
+    const { blobs } = await store.list({
+      prefix: 'group/',
+    })
+
+    expect(blobs).toEqual([])
+    expect(mockStore.fulfilled).toBeTruthy()
+  })
+
+  test('Handles missing content manual pagination', async () => {
+    const mockStore = new MockFetch().get({
+      headers: { authorization: `Bearer ${edgeToken}` },
+      response: new Response('<not_found>', { status: 404 }),
+      url: `${edgeURL}/${siteID}/site:${storeName}`,
+    })
+
+    globalThis.fetch = mockStore.fetch
+
+    const store = getStore({
+      edgeURL,
+      name: storeName,
+      token: edgeToken,
+      siteID,
+    })
+    const result: ListResult = {
+      blobs: [],
+      directories: [],
+    }
+
+    for await (const entry of store.list({ paginate: true })) {
+      result.blobs.push(...entry.blobs)
+      result.directories.push(...entry.directories)
+    }
+
+    expect(result.blobs).toEqual([])
+    expect(result.directories).toEqual([])
+    expect(mockStore.fulfilled).toBeTruthy()
+  })
 })

--- a/src/store_list.ts
+++ b/src/store_list.ts
@@ -56,6 +56,11 @@ const getListIterator = (client: Client, prefix: string): AsyncIterable<ListStor
             method: HTTPMethod.GET,
             parameters: nextParameters,
           })
+
+          if (res.status === 404) {
+            return { done: true, value: undefined }
+          }
+
           const page = (await res.json()) as ListStoresResponse
 
           if (page.next_cursor) {


### PR DESCRIPTION
Fixes issue described in: https://linear.app/netlify/issue/FRP-1224/blobs-list-throws-json-parse-error-on-404-paths

fixes error throws for 404ing content on listing functions. This updates store listing and content listing.