### PR TITLE
fix: add missing eu-central-1, ap-southeast-1 and ap-southeast-2 regions

### DIFF
--- a/src/region.ts
+++ b/src/region.ts
@@ -3,6 +3,9 @@ export const REGION_AUTO = 'auto'
 const regions = {
   'us-east-1': true,
   'us-east-2': true,
+  'eu-central-1': true,
+  'ap-southeast-1': true,
+  'ap-southeast-2': true,
 }
 
 export type Region = keyof typeof regions


### PR DESCRIPTION
🎉 Thanks for sending this pull request! 🎉

Fixes
```
InvalidBlobsRegionError: ap-southeast-2 is not a supported Netlify Blobs region. Supported values are: us-east-1, us-east-2.
```

kind of errors. We do have support for that (and some other regions) and forcing those specific regions was failing options validation.

With this change attempting to use region not from the list also print updated "Supported values":

```
InvalidBlobsRegionError: ap-southeast-3 is not a supported Netlify Blobs region. Supported values are: us-east-1, us-east-2, eu-central-1, ap-southeast-1, ap-southeast-2
```