### PR TITLE
fix: allow siteID and token to be passed in Functions v2 and Edge Fun…

### DIFF
--- a/src/store_factory.ts
+++ b/src/store_factory.ts
@@ -70,6 +70,23 @@ export const getStore: {
 
   if (typeof input?.name === 'string') {
     const { name } = input
+
+    if (typeof input?.siteID === 'string' && typeof input.token === 'string') {
+      const { siteID, token } = input
+      const clientOptions = getClientOptions(input, {
+        siteID,
+        token
+      })
+
+      if (!siteID || !token) {
+        throw new MissingBlobsEnvironmentError(['siteID', 'token'])
+      }
+
+      const client = new Client(clientOptions)
+
+      return new Store({ client, name })
+    }
+    
     const clientOptions = getClientOptions(input)
 
     if (!name) {

--- a/src/store_factory.ts
+++ b/src/store_factory.ts
@@ -83,7 +83,6 @@ export const getStore: {
 
   if (typeof input?.name === 'string') {
     const { name } = input
-
     const clientOptions = getClientOptions(input)
 
     if (!name) {

--- a/src/store_factory.ts
+++ b/src/store_factory.ts
@@ -69,18 +69,18 @@ export const getStore: {
   }
 
   if (typeof input?.name === 'string' && typeof input?.siteID === 'string' && typeof input?.token === 'string') {
-      const { siteID, token } = input
-      const clientOptions = getClientOptions(input, { siteID, token })
+    const { name, siteID, token } = input
+    const clientOptions = getClientOptions(input, { siteID, token })
 
-      if (!name || !siteID || !token) {
-        throw new MissingBlobsEnvironmentError(['name', 'siteID', 'token'])
-      }
-
-      const client = new Client(clientOptions)
-
-      return new Store({ client, name })
+    if (!name || !siteID || !token) {
+      throw new MissingBlobsEnvironmentError(['name', 'siteID', 'token'])
     }
 
+    const client = new Client(clientOptions)
+
+    return new Store({ client, name })
+  }
+  
   if (typeof input?.name === 'string') {
     const { name } = input    
     const clientOptions = getClientOptions(input)

--- a/src/store_factory.ts
+++ b/src/store_factory.ts
@@ -82,7 +82,7 @@ export const getStore: {
   }
   
   if (typeof input?.name === 'string') {
-    const { name } = input    
+    const { name } = input
     const clientOptions = getClientOptions(input)
 
     if (!name) {

--- a/src/store_factory.ts
+++ b/src/store_factory.ts
@@ -68,25 +68,21 @@ export const getStore: {
     return new Store({ client, name: input })
   }
 
-  if (typeof input?.name === 'string') {
-    const { name } = input
-
-    if (typeof input?.siteID === 'string' && typeof input.token === 'string') {
+  if (typeof input?.name === 'string' && typeof input?.siteID === 'string' && typeof input?.token === 'string') {
       const { siteID, token } = input
-      const clientOptions = getClientOptions(input, {
-        siteID,
-        token
-      })
+      const clientOptions = getClientOptions(input, { siteID, token })
 
-      if (!siteID || !token) {
-        throw new MissingBlobsEnvironmentError(['siteID', 'token'])
+      if (!name || !siteID || !token) {
+        throw new MissingBlobsEnvironmentError(['name', 'siteID', 'token'])
       }
 
       const client = new Client(clientOptions)
 
       return new Store({ client, name })
     }
-    
+
+  if (typeof input?.name === 'string') {
+    const { name } = input    
     const clientOptions = getClientOptions(input)
 
     if (!name) {

--- a/src/store_factory.ts
+++ b/src/store_factory.ts
@@ -80,9 +80,10 @@ export const getStore: {
 
     return new Store({ client, name })
   }
-  
+
   if (typeof input?.name === 'string') {
     const { name } = input
+
     const clientOptions = getClientOptions(input)
 
     if (!name) {


### PR DESCRIPTION
https://linear.app/netlify/issue/RUN-1401

When using Edge Functions or Functions v2, users could not specify a different site ID (along with the token) to store blobs on a different site. This was always fetched from the environment. This PR now allows that to happen. This was already possible in Functions v1 and any other Node.js application, so I didn't see any reason to penalize Edge Functions and Functions v2 users from doing the same. More details in Linear.

The solution for this already existed in the codebase but wasn't used. When calling `getStore()` with `siteID` and `token` (along with `name`), I now pass these options to `getClientOptions()` which automatically does what we need.

Initially I tried adding the check for siteID and token inside the if condition that handles `name`, but linter complained about nested if, so I had to split that condition into its own.

**Checklist**

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
